### PR TITLE
Fix __repr__ crash in Python 3

### DIFF
--- a/python/libmr.pyx
+++ b/python/libmr.pyx
@@ -35,6 +35,7 @@ from libcpp cimport bool
 from libcpp.string cimport string
 cimport numpy as np
 import numpy as np
+import sys
 
 cdef extern from "MetaRecognition.h":
     enum MR_fitting_type:
@@ -200,6 +201,8 @@ This is the commonly used function. After fitting, it returns the probability of
         """
         Serialize the MR object to a string. Use load_from_string to recover it.
         """
+        if sys.version_info >= (3,):
+            return str(self.thisptr.to_string(), 'utf-8')
         return self.thisptr.to_string()
     def __repr__(self):
         return "<MR object: %r>" % str(self)


### PR DESCRIPTION
In Python >3.0, the following results in a TypeError:

````
    >>> import libmr
    >>> mr = libmr.MR()
    >>> print(mr)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      TypeError: __str__ returned non-string (type bytes)
````

This patch restores the expected behavior of converting to str.

````
>>> import libmr
>>> libmr.MR()
<MR object: ''>
````
Tested on Python 2.7.12 and 3.5.2. Behavior in Python 2 remains the same.