### PR TITLE
Update setup.py, remove import numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 from setuptools.extension import Extension
-import numpy
 
 try:
     from Cython.Build import cythonize


### PR DESCRIPTION
If I add libmr to my projects requirements.txt, 
pip install -r requirements.txt tries to install libmr before numpy, so the setup.py script can't find numpy.