### PR TITLE
Revert "Update setup.py, remove import numpy"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 from setuptools.extension import Extension
+import numpy
 
 try:
     from Cython.Build import cythonize


### PR DESCRIPTION
Reverts Vastlab/libMR#5

I'm sorry, import numpy is needed for 'include_dirs = ["libMR/", numpy.get_include()],'.
Anyway there would be the same issue with Cython, which is a general pip dependency handling issue.
In this [discussion](https://github.com/h5py/h5py/issues/535#issuecomment-79158166) they mentioned to add cython to setup_requirements, but does also not work for me.