### PR TITLE
Dev/add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 from setuptools.extension import Extension
+import numpy
 
 try:
     from Cython.Build import cythonize


### PR DESCRIPTION
PEP 517/518 requires pyproject.toml to specify the build dependencies of a package. As pip>19.1 has become PEP 517/518 compliant, pyproject.toml is required when the wheel is build to specify build dependency.